### PR TITLE
Implemented IORE AIO MPI-IO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export CC = mpicc
 export CFLAGS += -I $(INCDIR)
 export CFLAGS += -Wall -Wextra
 export CFLAGS += -lm
-export CFLAGS += -DUSE_POSIX_AIO -DMETA_VERSION=$(VERSION)
+export CFLAGS += -DUSE_POSIX_AIO -DUSE_MPIIO_AIO -DMETA_VERSION=$(VERSION)
 
 # Executable file
 export EXEC = iore

--- a/include/iore_aio.h
+++ b/include/iore_aio.h
@@ -31,5 +31,6 @@ typedef struct iore_aio
  ******************************************************************************/
 
 iore_aio_t iore_aio_posix;
+iore_aio_t iore_aio_mpiio;
 
 #endif /* _IORE_AIO_H */

--- a/include/util.h
+++ b/include/util.h
@@ -89,6 +89,7 @@ void sync_rand_gen (MPI_Comm);
 char *human_readable (iore_size_t, int);
 char *get_parent_path (char *);
 char *get_file_name (char *);
+iore_size_t string_to_bytes (char *size_str);
 
 /******************************************************************************
  * M A C R O S

--- a/src/iore.c
+++ b/src/iore.c
@@ -58,11 +58,15 @@ iore_task_t *task;
 
 /* I/O APIs available */
 static iore_aio_t *available_aio[] = {
+#ifdef USE_MPIIO_AIO
+  &iore_aio_mpiio,
+#endif
 #ifdef USE_POSIX_AIO
   &iore_aio_posix,
 #endif
   NULL
 };
+
 
 /*****************************************************************************
  * M A I N                                                                   

--- a/src/iore_aio_mpiio.c
+++ b/src/iore_aio_mpiio.c
@@ -1,0 +1,151 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <mpi.h>
+
+#include "iore_aio.h"
+#include "iore_params.h"
+#include "iore_task.h"
+
+
+
+/******************************************************************************
+ * P R O T O T Y P E S
+ ******************************************************************************/
+static void *mpiio_create (iore_params_t *);
+static void *mpiio_open (iore_params_t *);
+static void mpiio_close (void *, iore_params_t *);
+static void mpiio_delete (iore_params_t *);
+static iore_size_t mpiio_io (void *, iore_size_t *, iore_size_t, iore_offset_t,
+			     access_t, iore_params_t *);
+
+/******************************************************************************
+ * D E C L A R A T I O N S
+ ******************************************************************************/
+
+iore_aio_t iore_aio_mpiio =
+  { "MPIIO", mpiio_create, mpiio_open, mpiio_close, mpiio_delete, mpiio_io };
+
+/*****************************************************************************
+ * G L O B A L S
+ *****************************************************************************/
+
+extern iore_task_t *task;
+
+/******************************************************************************
+ * F U N C T I O N S
+ ******************************************************************************/
+
+static void *
+mpiio_create (iore_params_t *params)
+{
+	MPI_File *fd;
+	int oflag = MPI_MODE_CREATE | MPI_MODE_RDWR;
+	
+	fd = (MPI_File *) malloc (sizeof(MPI_File));
+	if (fd == NULL)
+  	FATAL("Failed to allocate memory to file descriptor");
+ 
+	MPI_TRYCATCH(MPI_File_open(MPI_COMM_SELF, task->test_file_name, oflag, MPI_INFO_NULL, fd), 
+		"Could not create the test file");
+	
+	return ((void *) fd);
+} /* mpiio_create (iore_params_t *) */
+
+static void *
+mpiio_open (iore_params_t *params)
+{
+	MPI_File *fd;
+	int oflag = MPI_MODE_RDWR; 
+
+	fd = (MPI_File *) malloc (sizeof(MPI_File));
+	if (fd == NULL)
+  	FATAL("Failed to allocate memory to file descriptor");
+
+	MPI_TRYCATCH(MPI_File_open(MPI_COMM_SELF, task->test_file_name, oflag, MPI_INFO_NULL, fd), 
+		"Could not open the test file");
+
+  return ((void *) fd);
+} /* mpiio_open (iore_params_t *) */
+
+static void
+mpiio_close (void *fd, iore_params_t *params)
+{
+  MPI_TRYCATCH(MPI_File_close(fd),
+  	"Could not close the test file");
+  free (fd);
+} /* mpiio_close (void *, iore_params_t *) */
+
+static void
+mpiio_delete (iore_params_t *params)
+{ 
+  MPI_TRYCATCH(MPI_File_delete(task->test_file_name, MPI_INFO_NULL),
+  	"Could not delete the test file");
+} /* mpiio_delete (iore_params_t *) */
+
+static iore_size_t 
+mpiio_io (void *file, iore_size_t *buffer, iore_size_t length,
+	  iore_offset_t offset, access_t access, iore_params_t *params)
+{
+  iore_size_t remaining = length;
+  iore_size_t max, limit; 
+  iore_size_t data_transferred;
+  char *buf = (char *) buffer;
+  MPI_File *fd = (MPI_File *) file;
+  MPI_Offset mpi_offset = (MPI_Offset) offset;
+  int retries = 0;
+  MPI_Status status;
+  
+
+  max = string_to_bytes("2G");
+  limit = max - string_to_bytes("1K"); /* Maximum data writable/readable by the functions */
+
+  if (remaining >= max) /* More than 2 GiB of data */ 
+  {
+  		WARNF("Too much data for the task. Task %d will partially %s %lld of %lld bytes",
+		task->rank, (access == WRITE ? "write" : "read"), limit, remaining);
+  		remaining = limit;
+  		
+  		if (params->single_io_attempt)
+	    {
+	      FATAL("Single I/O attempt option defined; aborting");
+	      MPI_Abort (MPI_COMM_WORLD, -1);
+	    }
+
+	    if (retries > MAX_RETRIES)
+	  	{
+	    	FATAL("Too many retries; aborting");
+	    	MPI_Abort (MPI_COMM_WORLD, -1);
+	  	}
+
+  }
+  	
+  MPI_TRYCATCH(MPI_File_seek(*fd, mpi_offset, MPI_SEEK_SET),
+  	"Failed seeking file offset");
+
+  while (remaining > 0)
+  {
+    if (access == WRITE)
+		{
+	  	MPI_TRYCATCH(MPI_File_write(*fd, buf, remaining, MPI_BYTE, &status),
+	  		"Failed to write to file");
+		}
+    else /* READ */
+		{
+	  	MPI_TRYCATCH(MPI_File_read (*fd, buf, remaining, MPI_BYTE, &status),
+	  		"Failed to read from file");
+		}
+
+		MPI_Get_count( &status, MPI_BYTE, &data_transferred);
+		
+    remaining -= data_transferred;
+    buf += data_transferred;
+    retries++;
+  }
+  
+  return (length);
+} /* mpiio_io (void *, iore_size_t *, iore_size_t, iore_offset_t, ... *) */
+
+

--- a/src/parse_file.c
+++ b/src/parse_file.c
@@ -18,7 +18,6 @@
 static char *get_file_data (char *);
 static void parse_file_run (json_value *, iore_run_t *);
 static void parse_file_params (json_value *, iore_params_t *);
-static iore_size_t string_to_bytes (char *);
 
 /******************************************************************************
  * F U N C T I O N S
@@ -658,42 +657,3 @@ parse_file_params (json_value *params, iore_params_t *iore_params)
     }
 } /* parse_file_params (json_value *, iore_params_t *) */
 
-/*
- * Converts a string of the form 2, 4k, 8K, 16m, 32m, 64g, 128G into bytes.
- * Considers base two units.
- */
-static iore_size_t
-string_to_bytes (char *size_str)
-{
-  iore_size_t size = 0;
-  char unit;
-  int n;
-
-  n = sscanf(size_str, "%lld%c", &size, &unit);
-  if (n == 2)
-    {
-      switch ((int) unit)
-	{
-	case 'k':
-	case 'K':
-	  size <<= 10;
-	  break;
-	case 'm':
-	case 'M':
-	  size <<= 20;
-	  break;
-	case 'g':
-	case 'G':
-	  size <<= 30;
-	  break;
-	default:
-	  size = -1;
-	}
-    }
-  else if (n == 0)
-    {
-      size = -1;
-    }
-
-  return (size);
-} /* string_to_bytes (char *) */

--- a/src/util.c
+++ b/src/util.c
@@ -196,3 +196,43 @@ get_file_name (char *path)
 
   return (file);
 } /* get_file_name (char *) */
+
+/*
+ * Converts a string of the form 2, 4k, 8K, 16m, 32m, 64g, 128G into bytes.
+ * Considers base two units.
+ */
+iore_size_t
+string_to_bytes (char *size_str)
+{
+  iore_size_t size = 0;
+  char unit;
+  int n;
+
+  n = sscanf(size_str, "%lld%c", &size, &unit);
+  if (n == 2)
+    {
+      switch ((int) unit)
+  {
+  case 'k':
+  case 'K':
+    size <<= 10;
+    break;
+  case 'm':
+  case 'M':
+    size <<= 20;
+    break;
+  case 'g':
+  case 'G':
+    size <<= 30;
+    break;
+  default:
+    size = -1;
+  }
+    }
+  else if (n == 0)
+    {
+      size = -1;
+    }
+
+  return (size);
+} /* string_to_bytes (char *) */


### PR DESCRIPTION
- Added the file iore_aio_mpiio.c, containing the functions mpiio_create, mpiio_open, mpiio_close, mpiio_delete and mpiio_io implemented with MPICH
- Modified the makefile in order to compile and be able to use MPIIO API
- Added the declaration of the MPIIO API in iore_aio.h
- Moved the function string_to_bytes from parse_file.c to util.c in order to be reused